### PR TITLE
Configure prisma for deployment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,4 +4,5 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/garage-sale?schema=public"
+POSTGRES_PRISMA_URL="postgresql://postgres:postgres@localhost:5432/garage-sale?schema=public"
+POSTGRES_URL_NON_POOLING="postgresql://postgres:postgres@localhost:5432/garage-sale?schema=public"

--- a/db.ts
+++ b/db.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client'
+
+const prismaClientSingleton = () => {
+    return new PrismaClient()
+}
+
+declare const globalThis: {
+    prismaGlobal: ReturnType<typeof prismaClientSingleton>;
+} & typeof global;
+
+const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
+
+export default prisma
+
+if (process.env.NODE_ENV !== 'production') globalThis.prismaGlobal = prisma
+

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0",
     "next": "14.2.5",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "prisma": "^5.17.0"
   },
   "devDependencies": {
     "@types/node": "^20",
@@ -21,7 +23,6 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
     "postcss": "^8",
-    "prisma": "^5.17.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,8 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url = env("POSTGRES_PRISMA_URL") // uses connection pooling
+  directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
 }
 
 model Donator {


### PR DESCRIPTION
Update prisma configuration to use deployment configurations and mimic dev environment to the current deployment settings. Also setup prisma client described in [prisma <> next.js best practice](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/help-articles/nextjs-prisma-client-dev-practices) for development